### PR TITLE
Draw object mask and box simultaneously

### DIFF
--- a/scripts/mmros_wrapper_ckpt.py
+++ b/scripts/mmros_wrapper_ckpt.py
@@ -92,7 +92,7 @@ class MMRosWrapper:
                 # Test detection
                 plot = True
                 if plot:    
-                    pil_img = plot_result(img, bboxes, labels, scores, 0.3, True, self.anot_type, self.color_palette, masks)
+                    pil_img = plot_result(img, bboxes, labels, scores, 0.9, True, self.anot_type, self.color_palette, masks)
                     #pil_img = plot_masks(pil_img, masks, labels, scores) 
                 
                 # Test tracking

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -59,21 +59,26 @@ def plot_result(image_np, bboxes, labels, scores, score_threshold=0.2, plot_mask
     """
     
     
+    start_time = rospy.Time.now()
     id_to_label = get_id_to_label(plot_type) 
         
     image_pil = PILImage.fromarray(image_np)
-    
     draw = ImageDraw.Draw(image_pil)
     if plot_masks:
+        assert len(bboxes) == len(masks) == len(labels) == len(scores), "Mismatch in list lengths"
         for box, mask, label, score in zip(bboxes, masks, labels, scores):
             if score >= score_threshold:
-                plot_bbox(box, label, draw, id_to_label, color_dict, score)
                 color_ = label_to_color(label, color_dict)
                 image_pil = overlay_binary_mask(image_np, image_pil, mask, color=color_, alpha_true=0.4)
+                draw = ImageDraw.Draw(image_pil)
+                draw = plot_bbox(box, label, draw, id_to_label, color_dict, score)
     else:
         for box, label, score in zip(bboxes, labels, scores):
             if score >= score_threshold:
-                plot_bbox(box, label, draw, id_to_label, color_dict, score)
+                draw = plot_bbox(box, label, draw, id_to_label, color_dict, score)
+    end_time = rospy.Time.now()
+    duration = (end_time - start_time).to_sec()
+    print ("Plot duration:", duration)
     return image_pil
 
 def overlay_binary_mask(img_np, pil_img, mask, color=(255, 0, 0), alpha_true=0.3):


### PR DESCRIPTION
Fix the plot_result method to plot both the object mask and the box of the object. 
Increase the score_threshold for plot.